### PR TITLE
Allow using fullPaths=false in browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "mkdirp": "^0.5.0",
     "quick-temp": "^0.1.2",
     "rsvp": "^3.0.14",
-    "walk-sync": "^0.1.3"
+    "through2": "^0.6.5",
+    "walk-sync": "^0.1.3",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "babelify": "^5.0.4",


### PR DESCRIPTION
fullPaths=false is the default for browserfiy, so it's the default for
this module as well.

If you want fullPath support you need to specify the `fullPaths` option
to true in the browserify options:

``` javascript
var tree = fastBrowserify({
  browserify: {
     fullPaths: true
     ...
  },
  ...
});
```
