### PR TITLE
Invalidate bundle when entry point file has changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,7 +348,10 @@ FastBrowserify.prototype.invalidateCache = function() {
         bundle = this.bundles[bundleKey];
 
         // look through this bundle's dependencies and test if they are newer than the output file
+        // or check through the entry points and test if they are newer than the output file
         if (bundle.dependentFileNames[file] && ! _.include(invalidatedBundles, bundleKey)) {
+          invalidatedBundles.push(bundleKey);
+        } else if (_.include(bundle.entryPoints, file) && ! _.include(invalidatedBundles, bundleKey)) {
           invalidatedBundles.push(bundleKey);
         }
       }


### PR DESCRIPTION
Invalidates the bundle when the entry point file has changed. When the entry point file changes after a required file change, the bundle would not update. This enables invalidation in all cases to allow for more consistent bundle rebuilding.

Fixes https://github.com/caleb/broccoli-fast-browserify/issues/17

I wrote a test that fails without my code change and had logging statements to see the failure in the example provided https://github.com/kraftwer1/broccoli-fast-browserify-bug
